### PR TITLE
Change suggested ACS URL to enable more seamless SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ _Sync G Suite accounts with Azure active directory!_
 
 Note:
 
-ACS URL: `https://login.microsoftonline.com/login.srf`
+ACS URL: `https://login.microsoftonline.com/{YOUR_AAD_TENANT_ID}/saml2`
+  - ACS URL of `https://login.microsoftonline.com/login.srf` will also work, but may result in excessive sign-ins.
 
 Entity ID: `urn:federation:MicrosoftOnline`
 


### PR DESCRIPTION
With the suggested ACS URL here, things work, but there are many sign-in loops that sometimes seem to happen with certain applications - namely, Azure Data Explorer and the Azure portal.

Instead, if the AAD-tenant-specific SAML URL is used (found here: https://github.com/geekzter/azure-activedirectory-gsuite-federation), these sign in loops almost never occur. Since this was a change from a previous auth configuration, it required cookies to be cleared to work fully.

I discovered this today and my life has improved a lot 🙂